### PR TITLE
use the spread operator to convert NodeList to an Array.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  * @param {*} selectSelector A selector for select elements
  */
 export default function selectUrlSwitch(selectSelector) {
-  const selects = document.querySelectorAll(selectSelector);
+  const selects = [...document.querySelectorAll(selectSelector)];
   if (selects.length) {
     selects.forEach((select) => {
       select.addEventListener('change', () => {


### PR DESCRIPTION
Convert the NodeList to an Array to provide support for older browsers such as IE11. (Note: will only work In IE if compiled to ES5 with a toolchain such as Babel).